### PR TITLE
multiply the mex APRs by 100 to represent absolute values and not %

### DIFF
--- a/pkg/fetcher/mex_maiar.go
+++ b/pkg/fetcher/mex_maiar.go
@@ -10,10 +10,6 @@ import (
 "github.com/silviutroscot/istari-vision/pkg/log"
 )
 
-// get mex price  --------> service ---[if expired]-->  fetcher (Interface)
-// get mex apr    __/  |             \___[else]----> cache
-// get mex economics __/
-
 type MexEconomicsFetcherMaiar struct {
 	ApiEndpoint string
 	TokenName   string
@@ -105,12 +101,15 @@ func (mf *MexEconomicsFetcherMaiar) FetchMexEconomics() (MexEconomics, error) {
 				log.Error("error parsing the MEX LockedRewardsAPR from the Maiar API response: %s", err)
 				return economics, err
 			}
+			// multiply the APR by 100 as it is not percentage
+			economics.LockedRewardsAPR.Mul(economics.LockedRewardsAPR, BigFloatOneHundred)
 
 			_, _, err = economics.UnlockedRewardsAPR.Parse(farm.UnlockedRewardsAPR, 10)
 			if err != nil {
 				log.Error("error parsing the MEX UnlockedRewardsAPR from the Maiar API response: %s", err)
 				return economics, err
 			}
+			economics.UnlockedRewardsAPR.Mul(economics.UnlockedRewardsAPR, BigFloatOneHundred)
 		}
 	}
 

--- a/pkg/fetcher/mex_maiar_test.go
+++ b/pkg/fetcher/mex_maiar_test.go
@@ -111,8 +111,8 @@ func Test_MexEconomicsFetcherMaiar_GetMexEconomics(t *testing.T) {
 			economics, err := fetcher.FetchMexEconomics()
 			require.NoError(t, err)
 
-			assert.Equal(t, "8.577608885", economics.UnlockedRewardsAPR.String())
-			assert.Equal(t, "102.9313066", economics.LockedRewardsAPR.String())
+			assert.Equal(t, "857.7608885", economics.UnlockedRewardsAPR.String())
+			assert.Equal(t, "10293.13066", economics.LockedRewardsAPR.String())
 			assert.Equal(t, "0.0001994020661", economics.Price.String())
 		})
 

--- a/pkg/fetcher/utils.go
+++ b/pkg/fetcher/utils.go
@@ -1,6 +1,7 @@
 package fetcher
 
 import (
+	"math/big"
 	"net/http"
 	"time"
 )
@@ -15,6 +16,10 @@ const (
 
 	// MexMaiarFetcherEndpoint endpoint to fetch the MEX price and the APR for locked and unlocked staking
 	MexMaiarFetcherEndpoint = "https://testnet-exchange-graph.elrond.com/graphql"
+)
+
+var (
+	BigFloatOneHundred = big.NewFloat(100)
 )
 
 // httpClient will be used as a singleton and can be reused by any request


### PR DESCRIPTION
multiply the mex APRs by 100 to represent absolute values and not percentage